### PR TITLE
Fix gallery hover layout and continuation skeletons

### DIFF
--- a/src/components/home/ImageCard.vue
+++ b/src/components/home/ImageCard.vue
@@ -14,23 +14,19 @@
         :alt="image.alt || image.title"
         class="align-end image"
       />
-      <v-card-title
-        class="text-h7 text-white d-flex flex-column image-info-container"
-      >
+      <div class="text-white image-info-container">
         <div class="image-info" :class="{ 'on-hover': isHovering }">
-          <p>
+          <p class="image-info-title">
             {{ image.title }}
           </p>
-          <div>
-            <p class="text-caption" style="float: left">
+          <div class="image-info-meta">
+            <span class="image-info-date">
               {{ image.dateWhenTaken }}
-            </p>
-            <p class="text-caption" style="float: right">
-              Views: {{ image.views }}
-            </p>
+            </span>
+            <span class="image-info-views"> Views: {{ image.views }} </span>
           </div>
         </div>
-      </v-card-title>
+      </div>
       <v-dialog v-model="dialog" activator="parent" width="auto">
         <v-card v-if="dialog">
           <img
@@ -60,15 +56,12 @@ export default {
 </script>
 
 <style lang="scss">
-.v-card-title,
-.text-caption {
-  font-weight: 100 !important;
-}
-
 .item {
   break-inside: avoid;
   display: block;
   margin-bottom: var(--gallery-gap, 20px);
+  overflow: hidden;
+  position: relative;
   width: min(var(--gallery-card-width, 350px), 100%);
 }
 
@@ -77,33 +70,77 @@ export default {
 }
 
 .image {
+  display: block;
   width: 100%;
   height: auto;
 }
 
-.v-card-title {
+.image-info-container {
+  bottom: 0;
+  left: 0;
   padding: 0 !important;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  z-index: 1;
 }
 
 .image-info {
-  background: rgba(0, 0, 0, 0.7);
-  padding: 0.5em;
-  padding-left: 1em;
-  padding-right: 1em;
-  visibility: hidden;
+  background: linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0) 0%,
+    rgba(0, 0, 0, 0.76) 34%,
+    rgba(0, 0, 0, 0.86) 100%
+  );
+  box-sizing: border-box;
+  line-height: 1.2;
   opacity: 0;
+  padding: 28px 14px 12px;
   transition:
-    visibility 0s,
-    opacity 0.5s linear;
+    opacity 0.18s ease,
+    transform 0.18s ease,
+    visibility 0s linear 0.18s;
+  transform: translateY(8px);
+  visibility: hidden;
+  width: 100%;
 }
 
 .image-info.on-hover {
-  visibility: visible;
   opacity: 1;
+  transform: translateY(0);
+  transition-delay: 0s;
+  visibility: visible;
 }
 
-.image-info-container {
-  margin-top: -90px;
+.image-info-title {
+  font-size: 0.875rem;
+  font-weight: 300;
+  line-height: 1.2;
+  margin: 0 0 0.45rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.image-info-meta {
+  align-items: center;
+  display: flex;
+  font-size: 0.75rem;
+  font-weight: 300;
+  gap: 0.75rem;
+  justify-content: space-between;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.image-info-date,
+.image-info-views {
+  min-width: 0;
+}
+
+.image-info-date {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .modal-image {

--- a/src/components/home/InfiniteScrollContainer.vue
+++ b/src/components/home/InfiniteScrollContainer.vue
@@ -84,7 +84,9 @@ export default {
       this.load();
     },
     async load() {
-      const snapshot = await this.gallery.loadNext();
+      const request = this.gallery.loadNext();
+      this.applySnapshot(this.gallery.snapshot());
+      const snapshot = await request;
       this.applySnapshot(snapshot);
       return snapshot;
     },

--- a/src/layouts/default/PageHeader.vue
+++ b/src/layouts/default/PageHeader.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="header-root">
-    <div class="text-centered title font-weight-bold">Floyd Kretschmar</div>
+    <div class="text-centered site-title font-weight-bold">
+      Floyd Kretschmar
+    </div>
     <div class="menu">
       <ul>
         <li>
@@ -47,11 +49,17 @@ export default {
   color: #777;
   text-decoration: none;
 }
-.title {
+.site-title {
   width: 100%;
   text-align: center;
   font-size: 2rem;
   color: #222;
+}
+
+@media (prefers-color-scheme: dark) {
+  .site-title {
+    color: #e5e7eb;
+  }
 }
 
 @media only screen and (min-width: 1100px) {
@@ -59,7 +67,7 @@ export default {
     font-size: 1.6rem;
     font-weight: 300;
   }
-  .title {
+  .site-title {
     font-size: 2.75rem;
     width: auto;
     text-align: right;

--- a/src/services/gallery-service.js
+++ b/src/services/gallery-service.js
@@ -64,6 +64,9 @@ export function createGalleryService({ cache, flickrClient, pageSize }) {
   let pending = false;
 
   return {
+    snapshot() {
+      return snapshot;
+    },
     restore() {
       const cached = cache.read();
       if (cached.value) {

--- a/tests/behavior/gallery/first-load.test.js
+++ b/tests/behavior/gallery/first-load.test.js
@@ -462,6 +462,10 @@ describe("first gallery load", () => {
     await nextFrame();
 
     expect(requestedPageNumbers().filter((page) => page === 2)).toHaveLength(1);
+    expect(
+      document.querySelectorAll(".image-container .v-skeleton-loader").length,
+    ).toBeGreaterThan(0);
+    expect(visiblePhotoTitles()).toEqual(firstPage.map((photo) => photo.title));
 
     pageTwo.resolve(fetchResponse(pageResponse(secondPage, 2).data));
     await vi.waitFor(

--- a/tests/behavior/services/gallery-service.test.js
+++ b/tests/behavior/services/gallery-service.test.js
@@ -172,6 +172,55 @@ describe("gallery service", () => {
     await pending;
   });
 
+  it("exposes appended skeleton cards while a continuation page is pending", async () => {
+    const pageTwo = createDeferred();
+    const flickrClient = {
+      fetchPage: vi
+        .fn()
+        .mockResolvedValueOnce({
+          data: {
+            data: [
+              {
+                id: "first-page-photo",
+                thumbnail: {
+                  height: 320,
+                  url: "https://images.example.test/first-thumb.jpg",
+                },
+                title: "First page photo",
+              },
+            ],
+            totalPages: 2,
+          },
+        })
+        .mockReturnValueOnce(pageTwo.promise),
+    };
+    const service = createGalleryService({
+      cache: createEmptyCache(),
+      flickrClient,
+      pageSize: 1,
+    });
+
+    service.restore();
+    await service.loadNext();
+    const pending = service.loadNext();
+
+    expect(service.snapshot()).toMatchObject({
+      isLoading: true,
+      itemList: [
+        { id: "first-page-photo" },
+        {
+          id: "skeleton-0",
+          loaded: false,
+          thumbnail: { height: expect.any(Number) },
+        },
+      ],
+      pageNumber: 2,
+    });
+
+    pageTwo.resolve({ data: { data: [], totalPages: 2 } });
+    await pending;
+  });
+
   it("preserves the visible failed-load snapshot and allows a later load", async () => {
     const cache = createEmptyCache();
     const write = vi.spyOn(cache, "write");

--- a/tests/e2e/home-first-load.spec.js
+++ b/tests/e2e/home-first-load.spec.js
@@ -127,6 +127,55 @@ test("Home renders mocked Flickr photos after the first loading presentation", a
   await expect(page.getByAltText(photo.title, { exact: true })).toBeVisible();
 });
 
+test("Home photo metadata overlays without changing masonry card height", async ({
+  page,
+}) => {
+  await mockFlickr(page);
+  await mockImages(page);
+
+  await page.goto("/");
+
+  const card = page.locator(".item", {
+    has: page.getByAltText(photo.title, { exact: true }),
+  });
+  const image = page.getByAltText(photo.title, { exact: true });
+  await expect(image).toBeVisible();
+
+  const cardBefore = await card.boundingBox();
+  const imageBefore = await image.boundingBox();
+
+  await card.hover();
+  await expect(page.getByText(photo.title, { exact: true })).toBeVisible();
+  await expect(card.locator(".image-info-title")).toHaveCSS(
+    "font-size",
+    "14px",
+  );
+  await expect(card.locator(".image-info-meta")).toHaveCSS("display", "flex");
+  await expect(card.locator(".image-info-meta")).toHaveCSS(
+    "white-space",
+    "nowrap",
+  );
+  await expect(card.locator(".image-info")).toHaveCSS(
+    "transform",
+    "matrix(1, 0, 0, 1, 0, 0)",
+  );
+
+  const cardAfter = await card.boundingBox();
+  const imageAfter = await image.boundingBox();
+  const infoBox = await card.locator(".image-info").boundingBox();
+
+  expect(cardBefore).not.toBeNull();
+  expect(imageBefore).not.toBeNull();
+  expect(cardAfter).not.toBeNull();
+  expect(imageAfter).not.toBeNull();
+  expect(infoBox).not.toBeNull();
+  expect(Math.abs(cardAfter.height - imageAfter.height)).toBeLessThanOrEqual(1);
+  expect(Math.abs(cardBefore.height - cardAfter.height)).toBeLessThanOrEqual(1);
+  expect(infoBox.y + infoBox.height).toBeLessThanOrEqual(
+    imageAfter.y + imageAfter.height + 1,
+  );
+});
+
 test("Home keeps skeletons visible while mocked image fixtures are delayed", async ({
   page,
 }) => {
@@ -158,6 +207,9 @@ test("Home appends page two once when bottom scrolling repeats during the pendin
 
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
   await flickr.pageTwoPending;
+  expect(
+    await page.locator(".image-container .v-skeleton-loader").count(),
+  ).toBeGreaterThan(0);
   expect(flickr.requests.filter((pageNumber) => pageNumber === 2)).toHaveLength(
     1,
   );

--- a/tests/e2e/route-preview.spec.js
+++ b/tests/e2e/route-preview.spec.js
@@ -58,3 +58,28 @@ test("production preview serves Home and About routes through the SPA shell", as
   await expect(page.getByText("Welcome.")).toBeVisible();
   expect(requests).toEqual(["1"]);
 });
+
+test("site header remains visible for dark color schemes", async ({
+  browser,
+}) => {
+  const context = await browser.newContext({ colorScheme: "dark" });
+  const page = await context.newPage();
+
+  await page.route("https://flickr-service.fly.dev/photos/**", (route) => {
+    return route.fulfill({
+      contentType: "application/json",
+      json: {
+        data: photos,
+        totalPages: 1,
+      },
+    });
+  });
+
+  await page.goto("/");
+
+  const title = page.getByText("Floyd Kretschmar");
+  await expect(title).toBeVisible();
+  await expect(title).toHaveCSS("color", "rgb(229, 231, 235)");
+
+  await context.close();
+});


### PR DESCRIPTION
- Fix image-card hover metadata so it overlays the photo instead of increasing masonry card height.
- Reduce hover metadata typography and prevent unnecessary wrapping.
- Make the site title switch to light gray in dark color schemes.
- Restore masonry-grid skeleton placeholders while continuation photos are being fetched.
- Add behavior/e2e coverage for hover layout, dark header visibility, and pending continuation skeletons.