### PR TITLE
Fix gallery loading and dark-mode visual glitches

### DIFF
--- a/src/components/home/ImageCard.vue
+++ b/src/components/home/ImageCard.vue
@@ -6,7 +6,7 @@
     ></v-skeleton-loader>
   </v-card>
   <v-hover v-slot="{ isHovering, props }">
-    <v-card :width="loaded ? '' : 0" class="item" flat v-bind="props">
+    <v-card v-show="loaded" class="item" flat v-bind="props">
       <img
         @load="loaded = true"
         @error="$event.target.src = image.picture.fallback"
@@ -98,16 +98,13 @@ export default {
   padding: 28px 14px 12px;
   transition:
     opacity 0.18s ease,
-    transform 0.18s ease,
     visibility 0s linear 0.18s;
-  transform: translateY(8px);
   visibility: hidden;
   width: 100%;
 }
 
 .image-info.on-hover {
   opacity: 1;
-  transform: translateY(0);
   transition-delay: 0s;
   visibility: visible;
 }

--- a/src/layouts/default/Layout.vue
+++ b/src/layouts/default/Layout.vue
@@ -12,8 +12,14 @@ import ContentHost from "./ContentHost.vue";
 </script>
 
 <style>
+html,
+body,
 #app {
-  height: 100vh;
+  min-height: 100%;
+}
+
+#app {
+  min-height: 100vh;
   font-family: Poppins, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -22,13 +28,21 @@ import ContentHost from "./ContentHost.vue";
 }
 
 .v-application {
-  height: 100vh;
+  min-height: 100vh;
 }
 .v-application__wrap {
-  height: 100vh;
+  min-height: 100vh;
 }
 
 body {
+  background-color: #fff;
   margin: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  body,
+  #app {
+    background-color: #121212;
+  }
 }
 </style>

--- a/tests/behavior/gallery/image-card.test.js
+++ b/tests/behavior/gallery/image-card.test.js
@@ -50,6 +50,11 @@ describe("image card", () => {
     const image = document.querySelector("img.image");
 
     expect(document.querySelector(".v-skeleton-loader")).not.toBeNull();
+    expect(
+      Array.from(document.querySelectorAll(".item")).filter(
+        (item) => window.getComputedStyle(item).display !== "none",
+      ),
+    ).toHaveLength(1);
 
     image.dispatchEvent(new Event("load"));
     await nextFrame();

--- a/tests/e2e/home-first-load.spec.js
+++ b/tests/e2e/home-first-load.spec.js
@@ -143,6 +143,18 @@ test("Home photo metadata overlays without changing masonry card height", async 
 
   const cardBefore = await card.boundingBox();
   const imageBefore = await image.boundingBox();
+  const hiddenInfoBox = await card.locator(".image-info").boundingBox();
+
+  expect(cardBefore).not.toBeNull();
+  expect(imageBefore).not.toBeNull();
+  expect(hiddenInfoBox).not.toBeNull();
+  expect(
+    Math.abs(
+      hiddenInfoBox.y +
+        hiddenInfoBox.height -
+        (imageBefore.y + imageBefore.height),
+    ),
+  ).toBeLessThanOrEqual(0.25);
 
   await card.hover();
   await expect(page.getByText(photo.title, { exact: true })).toBeVisible();
@@ -155,10 +167,7 @@ test("Home photo metadata overlays without changing masonry card height", async 
     "white-space",
     "nowrap",
   );
-  await expect(card.locator(".image-info")).toHaveCSS(
-    "transform",
-    "matrix(1, 0, 0, 1, 0, 0)",
-  );
+  await expect(card.locator(".image-info")).toHaveCSS("opacity", "1");
 
   const cardAfter = await card.boundingBox();
   const imageAfter = await image.boundingBox();
@@ -171,9 +180,9 @@ test("Home photo metadata overlays without changing masonry card height", async 
   expect(infoBox).not.toBeNull();
   expect(Math.abs(cardAfter.height - imageAfter.height)).toBeLessThanOrEqual(1);
   expect(Math.abs(cardBefore.height - cardAfter.height)).toBeLessThanOrEqual(1);
-  expect(infoBox.y + infoBox.height).toBeLessThanOrEqual(
-    imageAfter.y + imageAfter.height + 1,
-  );
+  expect(
+    Math.abs(infoBox.y + infoBox.height - (imageAfter.y + imageAfter.height)),
+  ).toBeLessThanOrEqual(0.25);
 });
 
 test("Home keeps skeletons visible while mocked image fixtures are delayed", async ({
@@ -186,7 +195,49 @@ test("Home keeps skeletons visible while mocked image fixtures are delayed", asy
 
   await expect(page.getByText(photo.title, { exact: true })).toBeAttached();
   expect(await page.locator(".v-skeleton-loader").count()).toBeGreaterThan(0);
+  expect(
+    await page.locator(".image-container").evaluate((container) =>
+      Array.from(container.children)
+        .filter((item) => window.getComputedStyle(item).display !== "none")
+        .every(
+          (item) =>
+            item.querySelector(".v-skeleton-loader") &&
+            item.getBoundingClientRect().width > 0,
+        ),
+    ),
+  ).toBe(true);
   await expect(page.getByAltText(photo.title, { exact: true })).toBeVisible();
+});
+
+test("Home keeps the dark app background through the full scrollable gallery", async ({
+  browser,
+}) => {
+  const context = await browser.newContext({ colorScheme: "dark" });
+  const page = await context.newPage();
+  await mockFlickr(page, 0, createPhotos("dark-background", 20));
+  await mockImages(page);
+
+  await page.goto("/");
+
+  await expect(page.getByText("dark-background photo 20")).toBeAttached();
+  const background = await page.evaluate(() => {
+    const app = document.querySelector(".v-application");
+    const appBox = app.getBoundingClientRect();
+
+    return {
+      app: window.getComputedStyle(app).backgroundColor,
+      appHeight: appBox.height,
+      body: window.getComputedStyle(document.body).backgroundColor,
+      documentHeight: document.documentElement.scrollHeight,
+    };
+  });
+
+  expect(background.appHeight).toBeGreaterThanOrEqual(
+    background.documentHeight - 1,
+  );
+  expect(background.body).toBe(background.app);
+
+  await context.close();
 });
 
 test("Home appends page two once when bottom scrolling repeats during the pending request", async ({


### PR DESCRIPTION
## Summary
- keep unloaded image cards out of the masonry flow so skeletons align on first load
- let the app shell and document background grow together in dark mode
- keep image metadata overlays pinned to the actual image bottom

## Verification
- ./run.sh test
- ./run.sh format
- ./run.sh build
- review_developer: REVIEW: PASSED
- qa_engineer: QA: PASSED